### PR TITLE
Add enhanced debugging capabilities to MCP Server VS Code extension

### DIFF
--- a/mcp-servers/mcp-server-vscode/src/tools/debug_tools.d.ts
+++ b/mcp-servers/mcp-server-vscode/src/tools/debug_tools.d.ts
@@ -79,3 +79,66 @@ export declare const stopDebugSessionSchema: z.ZodObject<{
 }, {
     sessionName: string;
 }>;
+
+export declare const setBreakpoint: (params: {
+    filePath: string;
+    line: number;
+}) => Promise<{
+    content: {
+        type: string;
+        text: string;
+    }[];
+    isError: boolean;
+}>;
+
+export declare const setBreakpointSchema: z.ZodObject<{
+    filePath: z.ZodString;
+    line: z.ZodNumber;
+}, "strip", z.ZodTypeAny, {
+    filePath: string;
+    line: number;
+}, {
+    filePath: string;
+    line: number;
+}>;
+
+export declare const getCallStack: (params: {
+    sessionName?: string;
+}) => Promise<{
+    content: ({
+        type: string;
+        json: {
+            callStacks: {
+                sessionId: string;
+                sessionName: string;
+                threads: {
+                    threadId: number;
+                    threadName: string;
+                    stackFrames?: {
+                        id: number;
+                        name: string;
+                        source?: {
+                            name: string;
+                            path: string;
+                        };
+                        line: number;
+                        column: number;
+                    }[];
+                    error?: string;
+                }[];
+            };
+        };
+    } | {
+        type: string;
+        text: string;
+    })[];
+    isError: boolean;
+}>;
+
+export declare const getCallStackSchema: z.ZodObject<{
+    sessionName: z.ZodOptional<z.ZodString>;
+}, "strip", z.ZodTypeAny, {
+    sessionName?: string;
+}, {
+    sessionName?: string;
+}>;

--- a/mcp-servers/mcp-server-vscode/src/tools/debug_tools.d.ts
+++ b/mcp-servers/mcp-server-vscode/src/tools/debug_tools.d.ts
@@ -79,7 +79,6 @@ export declare const stopDebugSessionSchema: z.ZodObject<{
 }, {
     sessionName: string;
 }>;
-
 export declare const setBreakpoint: (params: {
     filePath: string;
     line: number;
@@ -90,7 +89,6 @@ export declare const setBreakpoint: (params: {
     }[];
     isError: boolean;
 }>;
-
 export declare const setBreakpointSchema: z.ZodObject<{
     filePath: z.ZodString;
     line: z.ZodNumber;
@@ -101,44 +99,93 @@ export declare const setBreakpointSchema: z.ZodObject<{
     filePath: string;
     line: number;
 }>;
-
 export declare const getCallStack: (params: {
     sessionName?: string;
 }) => Promise<{
-    content: ({
-        type: string;
-        json: {
-            callStacks: {
-                sessionId: string;
-                sessionName: string;
-                threads: {
-                    threadId: number;
-                    threadName: string;
-                    stackFrames?: {
-                        id: number;
-                        name: string;
-                        source?: {
-                            name: string;
-                            path: string;
-                        };
-                        line: number;
-                        column: number;
-                    }[];
-                    error?: string;
-                }[];
-            };
-        };
-    } | {
+    content: {
         type: string;
         text: string;
-    })[];
+    }[];
+    isError: boolean;
+} | {
+    content: {
+        type: string;
+        json: {
+            callStacks: ({
+                sessionId: string;
+                sessionName: string;
+                threads: any[];
+                error?: undefined;
+            } | {
+                sessionId: string;
+                sessionName: string;
+                error: string;
+                threads?: undefined;
+            })[];
+        };
+    }[];
     isError: boolean;
 }>;
-
 export declare const getCallStackSchema: z.ZodObject<{
     sessionName: z.ZodOptional<z.ZodString>;
 }, "strip", z.ZodTypeAny, {
-    sessionName?: string;
+    sessionName?: string | undefined;
 }, {
-    sessionName?: string;
+    sessionName?: string | undefined;
+}>;
+export declare const resumeDebugSession: (params: {
+    sessionId: string;
+}) => Promise<{
+    content: {
+        type: string;
+        text: string;
+    }[];
+    isError: boolean;
+}>;
+export declare const resumeDebugSessionSchema: z.ZodObject<{
+    sessionId: z.ZodString;
+}, "strip", z.ZodTypeAny, {
+    sessionId: string;
+}, {
+    sessionId: string;
+}>;
+export declare const getStackFrameVariables: (params: {
+    sessionId: string;
+    frameId: number;
+    threadId: number;
+    filter?: string;
+}) => Promise<{
+    content: {
+        type: string;
+        text: string;
+    }[];
+    isError: boolean;
+} | {
+    content: {
+        type: string;
+        json: {
+            sessionId: string;
+            frameId: number;
+            threadId: number;
+            variablesByScope: any[];
+            filter: string | undefined;
+        };
+    }[];
+    isError: boolean;
+}>;
+export declare const getStackFrameVariablesSchema: z.ZodObject<{
+    sessionId: z.ZodString;
+    frameId: z.ZodNumber;
+    threadId: z.ZodNumber;
+    filter: z.ZodOptional<z.ZodString>;
+}, "strip", z.ZodTypeAny, {
+    sessionId: string;
+    frameId: number;
+    threadId: number;
+    filter?: string | undefined;
+}, {
+    sessionId: string;
+    frameId: number;
+    threadId: number;
+    filter?: string | undefined;
 }>;

--- a/mcp-servers/mcp-server-vscode/src/tools/debug_tools.ts
+++ b/mcp-servers/mcp-server-vscode/src/tools/debug_tools.ts
@@ -163,14 +163,22 @@ export const setBreakpoint = async (params: { filePath: string; line: number }) 
         }
 
         // Create a new breakpoint
-        const breakpoint = new vscode.SourceBreakpoint(
-            new vscode.Location(fileUri, new vscode.Position(line - 1, 0))
-        );
+        const breakpoint = new vscode.SourceBreakpoint(new vscode.Location(fileUri, new vscode.Position(line - 1, 0)));
 
-        // Add the breakpoint
-        const added = vscode.debug.addBreakpoints([breakpoint]);
+        // Add the breakpoint - note that addBreakpoints returns void, not an array
+        vscode.debug.addBreakpoints([breakpoint]);
 
-        if (added.length === 0) {
+        // Check if the breakpoint was successfully added by verifying it exists in VS Code's breakpoints
+        const breakpoints = vscode.debug.breakpoints;
+        const breakpointAdded = breakpoints.some((bp) => {
+            if (bp instanceof vscode.SourceBreakpoint) {
+                const loc = bp.location;
+                return loc.uri.fsPath === fileUri.fsPath && loc.range.start.line === line - 1;
+            }
+            return false;
+        });
+
+        if (!breakpointAdded) {
             return {
                 content: [
                     {
@@ -269,10 +277,12 @@ export const getCallStack = async (params: { sessionName?: string }) => {
                                     stackFrames: stackTrace.stackFrames.map((frame: any) => ({
                                         id: frame.id,
                                         name: frame.name,
-                                        source: frame.source ? {
-                                            name: frame.source.name,
-                                            path: frame.source.path,
-                                        } : undefined,
+                                        source: frame.source
+                                            ? {
+                                                  name: frame.source.name,
+                                                  path: frame.source.path,
+                                              }
+                                            : undefined,
                                         line: frame.line,
                                         column: frame.column,
                                     })),
@@ -284,7 +294,7 @@ export const getCallStack = async (params: { sessionName?: string }) => {
                                     error: error instanceof Error ? error.message : String(error),
                                 };
                             }
-                        })
+                        }),
                     );
 
                     return {
@@ -299,7 +309,7 @@ export const getCallStack = async (params: { sessionName?: string }) => {
                         error: error instanceof Error ? error.message : String(error),
                     };
                 }
-            })
+            }),
         );
 
         return {
@@ -326,5 +336,160 @@ export const getCallStack = async (params: { sessionName?: string }) => {
 
 // Zod schema for validating get_call_stack parameters.
 export const getCallStackSchema = z.object({
-    sessionName: z.string().optional().describe('The name of the debug session to get call stack for. If not provided, returns call stacks for all active sessions.'),
+    sessionName: z
+        .string()
+        .optional()
+        .describe(
+            'The name of the debug session to get call stack for. If not provided, returns call stacks for all active sessions.',
+        ),
+});
+
+/**
+ * Resume execution of a debug session that has been paused (e.g., by a breakpoint).
+ *
+ * @param params - Object containing the sessionId of the debug session to resume.
+ */
+export const resumeDebugSession = async (params: { sessionId: string }) => {
+    const { sessionId } = params;
+
+    // Find the session with the given ID
+    const session = activeSessions.find((s) => s.id === sessionId);
+    if (!session) {
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: `No debug session found with ID '${sessionId}'.`,
+                },
+            ],
+            isError: true,
+        };
+    }
+
+    try {
+        // Send the continue request to the debug adapter
+        await session.customRequest('continue', { threadId: 0 }); // 0 means all threads
+
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: `Resumed debug session '${session.name}'.`,
+                },
+            ],
+            isError: false,
+        };
+    } catch (error) {
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: `Error resuming debug session: ${error instanceof Error ? error.message : String(error)}`,
+                },
+            ],
+            isError: true,
+        };
+    }
+};
+
+// Zod schema for validating resume_debug_session parameters.
+export const resumeDebugSessionSchema = z.object({
+    sessionId: z.string().describe('The ID of the debug session to resume.'),
+});
+
+/**
+ * Get variables from a specific stack frame.
+ *
+ * @param params - Object containing sessionId, frameId, threadId, and optional filter to get variables from.
+ */
+export const getStackFrameVariables = async (params: {
+    sessionId: string;
+    frameId: number;
+    threadId: number;
+    filter?: string;
+}) => {
+    const { sessionId, frameId, threadId, filter } = params;
+
+    // Find the session with the given ID
+    const session = activeSessions.find((s) => s.id === sessionId);
+    if (!session) {
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: `No debug session found with ID '${sessionId}'.`,
+                },
+            ],
+            isError: true,
+        };
+    }
+
+    try {
+        // First, get the scopes for the stack frame
+        const scopes = await session.customRequest('scopes', { frameId });
+
+        // Then, get variables for each scope
+        const variablesByScope = await Promise.all(
+            scopes.scopes.map(async (scope: { name: string; variablesReference: number }) => {
+                if (scope.variablesReference === 0) {
+                    return {
+                        scopeName: scope.name,
+                        variables: [],
+                    };
+                }
+
+                const response = await session.customRequest('variables', {
+                    variablesReference: scope.variablesReference,
+                });
+
+                // Apply filter if provided
+                let filteredVariables = response.variables;
+                if (filter) {
+                    const filterRegex = new RegExp(filter, 'i'); // Case insensitive match
+                    filteredVariables = response.variables.filter((variable: { name: string }) =>
+                        filterRegex.test(variable.name),
+                    );
+                }
+
+                return {
+                    scopeName: scope.name,
+                    variables: filteredVariables,
+                };
+            }),
+        );
+
+        return {
+            content: [
+                {
+                    type: 'json',
+                    json: {
+                        sessionId,
+                        frameId,
+                        threadId,
+                        variablesByScope,
+                        filter: filter || undefined,
+                    },
+                },
+            ],
+            isError: false,
+        };
+    } catch (error) {
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: `Error getting variables: ${error instanceof Error ? error.message : String(error)}`,
+                },
+            ],
+            isError: true,
+        };
+    }
+};
+
+// Zod schema for validating get_stack_frame_variables parameters.
+export const getStackFrameVariablesSchema = z.object({
+    sessionId: z.string().describe('The ID of the debug session.'),
+    frameId: z.number().describe('The ID of the stack frame to get variables from.'),
+    threadId: z.number().describe('The ID of the thread containing the stack frame.'),
+    filter: z.string().optional().describe('Optional filter pattern to match variable names.'),
 });


### PR DESCRIPTION
## Description
This PR enhances the VS Code MCP Server extension with improved debugging capabilities:

- Fixed the `setBreakpoint` implementation to properly verify breakpoint setting
- Added `resumeDebugSession` tool to continue execution after a breakpoint hit
- Added `getStackFrameVariables` tool to inspect variables at breakpoints
- Added variable name filtering capability to limit stack frame variable output

These improvements allow the MCP Server to provide rich debugging capabilities to AI assistants through the MCP protocol, enabling them to control VS Code's debugging features for advanced debugging workflows.

## Testing
Tested with PowerShell scripts by setting breakpoints, inspecting variables, and resuming execution.